### PR TITLE
add various forms of metadata from the schema

### DIFF
--- a/src/jsonschema_to_typeddict/converter.py
+++ b/src/jsonschema_to_typeddict/converter.py
@@ -362,6 +362,7 @@ def convert_schema_to(schema_path: Path, output: Path, root_name: str) -> None:
     result = """# This file is generated. Manual changes will be lost
 # fmt: off
 # ruff: noqa
+# mypy: disable-error-code="misc"
 from __future__ import annotations
 
 import typing_extensions as typ

--- a/tests/sample_schema.json
+++ b/tests/sample_schema.json
@@ -128,13 +128,27 @@
         "dict_definition": {
             "type": "object",
             "additionalProperties": false,
+            "title": "Title",
+            "description": "A description of the schema.",
+            "default": {
+                "nested_ref": "s010_cave",
+                "number": 0
+            },
+            "examples": [
+                {
+                    "nested_ref": "s020_magma",
+                    "number": 1
+                }
+            ],
             "properties": {
                 "nested_ref": {
                     "$ref": "#/$defs/scenario_name"
                 },
                 "number": {
                     "type": "integer",
-                    "default": 0
+                    "default": 0,
+                    "minimum": 0,
+                    "exclusiveMaximum": 100
                 }
             },
             "required": [

--- a/tests/sample_schema.pyi
+++ b/tests/sample_schema.pyi
@@ -1,6 +1,7 @@
 # This file is generated. Manual changes will be lost
 # fmt: off
 # ruff: noqa
+# mypy: disable-error-code="misc"
 from __future__ import annotations
 
 import typing_extensions as typ

--- a/tests/sample_schema.pyi
+++ b/tests/sample_schema.pyi
@@ -15,7 +15,9 @@ class DictDefinition(typ.TypedDict):
     
     A description of the schema.
     
-    Examples: [{'nested_ref': 's010_cave', 'number': 0}, {'nested_ref': 's020_magma', 'number': 1}]
+    Examples:
+        `{'nested_ref': 's010_cave', 'number': 0}`
+        `{'nested_ref': 's020_magma', 'number': 1}`
     """
 
     nested_ref: ScenarioName

--- a/tests/sample_schema.pyi
+++ b/tests/sample_schema.pyi
@@ -9,8 +9,16 @@ import typing_extensions as typ
 # Definitions
 @typ.final
 class DictDefinition(typ.TypedDict):
+    """
+    Title
+    
+    A description of the schema.
+    
+    Examples: [{'nested_ref': 's010_cave', 'number': 0}, {'nested_ref': 's020_magma', 'number': 1}]
+    """
+
     nested_ref: ScenarioName
-    number: int
+    number: typ.Annotated[int, '0 <= value < 100'] = 0
 
 ScenarioName = typ.Literal[
     's010_cave',
@@ -46,9 +54,9 @@ SampleComplexNonTotalObjectPickupType = typ.Literal[
 
 class SampleComplexNonTotalObject(typ.TypedDict, total=False):
     pickup_type: typ.Required[SampleComplexNonTotalObjectPickupType]
-    model: list[str]
+    model: typ.Annotated[list[str], 'len() >= 1']
     pickup_lua_callback: str
-    pickup_actordef: str
+    pickup_actordef: typ.Annotated[str, '/[a-zA-Z0-9_/]+?\\.bmsad/']
     pickup_string_key: str
 
 @typ.final


### PR DESCRIPTION
general fields: `title`, `description`, `examples`, `default`
array fields: `minItems`, `maxItems`, `uniqueItems`
dict fields: `minProperties`, `maxProperties`
string fields: `minLength`, `maxLength`, `pattern`
number fields: `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`